### PR TITLE
Update nooploop.ino

### DIFF
--- a/nooploop.ino
+++ b/nooploop.ino
@@ -1,12 +1,12 @@
 void setup() {
   // put your setup code here, to run once:
-  Serial1.begin(921600);
+  Serial.begin(921600);
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
   char buf[128]={0x54,0,1};
   buf[127]=0x55;
-  Serial1.write(buf,128);  
+  Serial.write(buf,128);  
   delay(5000);
 }


### PR DESCRIPTION
#1  if a board has multiple UART we can use serial1 but if it is single UART serial only should be used. Serial1 wont work. hope it helps.